### PR TITLE
Enable ksm on boot

### DIFF
--- a/rootfs/usr/lib/tmpfiles.d/ksm.conf
+++ b/rootfs/usr/lib/tmpfiles.d/ksm.conf
@@ -1,0 +1,2 @@
+# Type Path                                     Mode User Group Age         Argument
+w      /sys/kernel/mm/ksm/advisor_mode          -    -    -     -           scan-time


### PR DESCRIPTION
Set KSM to scan-time so it can dedupe memory pages. This is beneficial for running VMs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified system configuration to enable write access to kernel memory swap settings during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->