### PR TITLE
Remove sha from Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:stable@sha256:c39e73eff276872c698a53f54f91ba47621af9103b61a4b66f6c715003e598ff
+FROM quay.io/fedora/fedora-coreos:stable
 
 COPY rootfs/ /
 


### PR DESCRIPTION
Dependabot will not update the sha so this will allow future updated images to be used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image configuration to pull the latest stable release instead of a previously pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->