### PR TITLE
Create fake rfkill write area

### DIFF
--- a/rootfs/usr/lib/tmpfiles.d/rfkill.conf
+++ b/rootfs/usr/lib/tmpfiles.d/rfkill.conf
@@ -1,0 +1,3 @@
+# Work around rfkill not being able to write to /var/lib/rfkill early in boot
+d /run/rfkill 0755 root root -
+L /var/lib/rfkill - - - - /run/rfkill


### PR DESCRIPTION
RFKill tries to write to /var/lib/rfkill, but /var is not always writable that early. This creates a temporary space for it to write to. Persistence is removed, but unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added system configuration for improved rfkill handling during early boot to ensure wireless radio frequency kill switch functionality operates reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JasonN3/kube_node/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->