### PR TITLE
Stable seems to be broken

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:stable
+FROM quay.io/fedora/fedora-coreos:testing
 
 # Install general packages
 RUN dnf install -y jq udisks2

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:44.20260419.3.1
+FROM quay.io/fedora/fedora-coreos:44.20260516.20.1
 
 # Install general packages
 RUN dnf install -y jq udisks2

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:testing
+FROM quay.io/fedora/fedora-coreos:44.20260519.20.1
 
 # Install general packages
 RUN dnf install -y jq udisks2

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:44.20260516.20.1
+FROM quay.io/fedora/fedora-coreos:44.20260419.3.1
 
 # Install general packages
 RUN dnf install -y jq udisks2

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:44.20260519.20.1
+FROM quay.io/fedora/fedora-coreos:44.20260419.3.1
 
 # Install general packages
 RUN dnf install -y jq udisks2


### PR DESCRIPTION
Since stable is unable to boot. `ostree-system-generator` exits with result 1.
Per https://github.com/coreos/fedora-coreos-streams/commits/main/streams/stable.json, 44.20260419.3.1 is the previous stable version

| Version | Working |
|---|---|
| 44.20260519.20.1 | No |
| 44.20260419.3.1 | Yes |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to use a specific pinned version instead of the stable tag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JasonN3/kube_node/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->