### PR TITLE
Update Fedora CoreOS base image version to 44.20260523.3.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-coreos:44.20260419.3.1
+FROM quay.io/fedora/fedora-coreos:44.20260523.3.1
 
 # Install general packages
 RUN dnf install -y jq udisks2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to the latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->