### PR TITLE
Automatically update the container tag to stable

### DIFF
--- a/.github/workflows/update_containerfile.yaml
+++ b/.github/workflows/update_containerfile.yaml
@@ -1,0 +1,38 @@
+name: Update Containerfile Base Image
+
+on:
+  schedule:
+    # Weekly on Sunday at 06:00 UTC
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+jobs:
+  update-containerfile:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch latest Fedora CoreOS tag
+        id: fedora-coreos
+        run: |
+          tag=$(curl -fsSL https://raw.githubusercontent.com/coreos/fedora-coreos-streams/refs/heads/main/streams/stable.json | jq -r '.architectures.x86_64.artifacts.metal.release')
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Update Containerfile
+        run: |
+          sed -i "1s|^FROM quay.io/fedora/fedora-coreos:.*|FROM quay.io/fedora/fedora-coreos:${{ steps.fedora-coreos.outputs.tag }}|" Containerfile
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: update Fedora CoreOS base image to ${{ steps.fedora-coreos.outputs.tag }}"
+          branch: chore/update-fedora-coreos-base-image
+          title: "chore: update Fedora CoreOS base image to ${{ steps.fedora-coreos.outputs.tag }}"
+          body: |
+            Update the Containerfile base image to Fedora CoreOS release `${{ steps.fedora-coreos.outputs.tag }}`.
+          labels: |
+            dependencies

--- a/.github/workflows/update_containerfile.yaml
+++ b/.github/workflows/update_containerfile.yaml
@@ -14,20 +14,31 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1d96e77243dd4195152a514d7285122588147820 # v6
+        with:
+          persist-credentials: false
 
       - name: Fetch latest Fedora CoreOS tag
         id: fedora-coreos
         run: |
-          tag=$(curl -fsSL https://raw.githubusercontent.com/coreos/fedora-coreos-streams/refs/heads/main/streams/stable.json | jq -r '.architectures.x86_64.artifacts.metal.release')
+          tag=$(curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
+            https://raw.githubusercontent.com/coreos/fedora-coreos-streams/refs/heads/main/streams/stable.json \
+            | jq -r '.architectures.x86_64.artifacts.metal.release')
+          [[ "$tag" =~ ^[0-9\.]+$ ]] || {
+            echo "Invalid Fedora CoreOS tag: $tag" >&2
+            exit 1
+          }
+
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Update Containerfile
+        env:
+          FCOS_TAG: ${{ steps.fedora-coreos.outputs.tag }}
         run: |
-          sed -i "1s|^FROM quay.io/fedora/fedora-coreos:.*|FROM quay.io/fedora/fedora-coreos:${{ steps.fedora-coreos.outputs.tag }}|" Containerfile
+          sed -i "1s|^FROM quay.io/fedora/fedora-coreos:.*|FROM quay.io/fedora/fedora-coreos:${FCOS_TAG}|" Containerfile
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@9c44e0f2fa5c68aadc6c6fdd49d8fcc4a3a2e79e # v7
         with:
           commit-message: "chore: update Fedora CoreOS base image to ${{ steps.fedora-coreos.outputs.tag }}"
           branch: chore/update-fedora-coreos-base-image


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow that runs weekly to check for updates to the Fedora CoreOS base image and automatically opens pull requests proposing updated image tags for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->