### PR TITLE
Define boot parition information

### DIFF
--- a/rootfs/usr/lib/bootc/install/config.toml
+++ b/rootfs/usr/lib/bootc/install/config.toml
@@ -1,10 +1,10 @@
 version = "1.0"
 
-[storage.filesystems.boot]
+[install.filesystems.boot]
 mountpoint = "/boot"
 size = "1GiB"
 format = "ext4"
 
-[storage.filesystems.root]
+[install.filesystems.root]
 mountpoint = "/"
 format = "xfs"

--- a/rootfs/usr/lib/bootc/install/config.toml
+++ b/rootfs/usr/lib/bootc/install/config.toml
@@ -1,0 +1,10 @@
+version = "1.0"
+
+[storage.filesystems.boot]
+mountpoint = "/boot"
+size = "1GiB"
+format = "ext4"
+
+[storage.filesystems.root]
+mountpoint = "/"
+format = "xfs"


### PR DESCRIPTION
bootc is creating the partition, but without the definition, it is not creating it with the right size or formatting it. 